### PR TITLE
Resource名の予約語を追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ Values
 | ID_PREFIX | `[clay-id]` |
 
 
+##### ReservedResources
+
+| Key | Value |
+| --- | ---- |
+| SCHEMA | `ClaySchema` |
+| SCHEMA_PROPERTIES | `ClaySchemaProperty` |
+| SIGNATURE | `ClaySignature` |
+| TRACE | `ClayTrace` |
+| LOCAL | `ClayLocal` |
+
+
 ##### SerialTypes
 
 | Key | Value |

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,5 +12,6 @@ module.exports = {
   get DriverSpec () { return d(require('./driver_spec')) },
   get IdSpec () { return d(require('./id_spec')) },
   get LogPrefixes () { return d(require('./log_prefixes')) },
+  get ReservedResources () { return d(require('./reserved_resources')) },
   get SerialTypes () { return d(require('./serial_types')) }
 }

--- a/lib/reserved_resources.js
+++ b/lib/reserved_resources.js
@@ -1,0 +1,16 @@
+/**
+ * Resource names reserved for ClayDB
+ * @namespace ReservedResources
+ */
+'use strict'
+
+/** Resource for schemas */
+exports.SCHEMA = 'ClaySchema'
+/** Resource for schema properties */
+exports.SCHEMA_PROPERTIES = 'ClaySchemaProperty'
+/** Resource for signatures */
+exports.SIGNATURE = 'ClaySignature'
+/** Resource for traces */
+exports.TRACE = 'ClayTrace'
+/** Resource for local data */
+exports.LOCAL = 'ClayLocal'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-constants",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Constant variables for clay",
   "main": "lib",
   "browser": "shim/browser",

--- a/test/reserved_resources_test.js
+++ b/test/reserved_resources_test.js
@@ -1,0 +1,30 @@
+/**
+ * Test case for reservedResources.
+ * Runs with mocha.
+ */
+'use strict'
+
+const ReservedResources = require('../lib/reserved_resources.js')
+const assert = require('assert')
+const co = require('co')
+
+describe('reserved-resources', function () {
+  this.timeout(3000)
+
+  before(() => co(function * () {
+
+  }))
+
+  after(() => co(function * () {
+
+  }))
+
+  it('Reserved resources', () => co(function * () {
+    for (let name of Object.keys(ReservedResources)) {
+      assert.ok(ReservedResources[ name ])
+      assert.ok(/^Clay/.test(ReservedResources[ name ]))
+    }
+  }))
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
ClayDBにおけるResourceは、形式を一にするデータの集合。
RDBにおけるテーブル、Restにおけるエンドポイント、NoSQLのcollectionのようなもの。

実用時には、アプリケーション側の要請によって決められるものと、ClayDBが内部的に使用するものが同一ストレージ上に混在することになる。なので、後者を先に予約語として定めてバリデートできるようにする必要がある