### PR TITLE
Add entity spec

### DIFF
--- a/lib/entity_spec.js
+++ b/lib/entity_spec.js
@@ -1,0 +1,8 @@
+/**
+ * Specifications for entity
+ * @namespace EntitySpec
+ */
+'use strict'
+
+/** Reserved attribute names */
+exports.RESERVED_ATTRIBUTES = 'id,$$at,$$seal'

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ let d = (module) => module && module.default || module
 module.exports = {
   get CryptFormat () { return d(require('./crypt_format')) },
   get DriverSpec () { return d(require('./driver_spec')) },
+  get EntitySpec () { return d(require('./entity_spec')) },
   get IdSpec () { return d(require('./id_spec')) },
   get LogPrefixes () { return d(require('./log_prefixes')) },
   get LumpSpec () { return d(require('./lump_spec')) },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-constants",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Constant variables for clay",
   "main": "lib",
   "browser": "shim/browser",

--- a/test/entity_spec_test.js
+++ b/test/entity_spec_test.js
@@ -1,0 +1,29 @@
+/**
+ * Test case for entitySpec.
+ * Runs with mocha.
+ */
+'use strict'
+
+const EntitySpec = require('../lib/entity_spec.js')
+const assert = require('assert')
+const co = require('co')
+
+describe('entity-spec', function () {
+  this.timeout(3000)
+
+  before(() => co(function * () {
+
+  }))
+
+  after(() => co(function * () {
+
+  }))
+
+  it('Entity spec', () => co(function * () {
+    for (let name of Object.keys(EntitySpec)) {
+      assert.ok(EntitySpec[ name ])
+    }
+  }))
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
Entityの仕様を追加した

* `id`: 識別子
* `$$at`: 最終更新日
* `$$seal`: 署名

をシステム用の予約語とし、entityのattributeとしては使えないようにする