### PR TITLE
署名の形式をhexにした

### DIFF
--- a/lib/crypt_format.js
+++ b/lib/crypt_format.js
@@ -9,3 +9,6 @@ exports.DIGEST_ALGORITHM = 'sha256'
 
 /** Bits for key generation */
 exports.GENERATE_BITS = 512
+
+/** Format for signature */
+exports.SIGN_FORMAT = 'hex'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-constants",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Constant variables for clay",
   "main": "lib",
   "browser": "shim/browser",


### PR DESCRIPTION
ClayResourceの$$sealに使う署名の形式をhexにした。

CryptoモジュールのデフォルトはbinaryをwrapしたBufferだが、DBに出し入れするのでhex文字列の方が扱いが楽

https://nodejs.org/api/crypto.html#crypto_sign_sign_private_key_output_format
