### PR TITLE
リソース名にピリオドを許容するようにした。

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Values
 
 | Key | Value |
 | --- | ---- |
-| NAME_PATTERN | `/^[A-Za-z][A-Za-za-z0-9\-_]*$/` |
+| NAME_PATTERN | `/^[A-Za-z][A-Za-za-z0-9\-_\.]*$/` |
 | DOMAIN_PATTERN | `/^[A-Za-z][A-Za-za-z0-9\-_\.]*$/` |
 
 

--- a/lib/resource_spec.js
+++ b/lib/resource_spec.js
@@ -5,7 +5,7 @@
 'use strict'
 
 /** Available letters for resource name string */
-exports.NAME_PATTERN = /^[A-Za-z][A-Za-za-z0-9\-_]*$/
+exports.NAME_PATTERN = /^[A-Za-z][A-Za-za-z0-9\-_\.]*$/
 
 /** Available letters for resource domain string */
 exports.DOMAIN_PATTERN = /^[A-Za-z][A-Za-za-z0-9\-_\.]*$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-constants",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Constant variables for clay",
   "main": "lib",
   "browser": "shim/browser",

--- a/test/resource_spec_test.js
+++ b/test/resource_spec_test.js
@@ -25,9 +25,9 @@ describe('resource-spec', function () {
     ok(NAME_PATTERN.test('wonderful-world'))
     ok(NAME_PATTERN.test('wonderful_world'))
     ok(!NAME_PATTERN.test('wonderful world'))
+    ok(NAME_PATTERN.test('ClySchema.WonderfulWorld'))
 
     ok(DOMAIN_PATTERN.test('latest.com'))
-    ok(!DOMAIN_PATTERN.test(''))
   }))
 })
 


### PR DESCRIPTION
メタリソースを表す際のnamepathのためにカンマを許容するように仕様を変えた

例えばProductリソース用のpolicy管理リソースの名称は`ClyPolicy.Product`のようになる