### PR TITLE
エンティティの予約メソッド名を定義した

### DIFF
--- a/lib/entity_spec.js
+++ b/lib/entity_spec.js
@@ -6,3 +6,6 @@
 
 /** Reserved attribute names */
 exports.RESERVED_ATTRIBUTES = 'id,$$at,$$seal,$$by,$$policy,$$as'
+
+/** Reserved method names */
+exports.RESERVED_METHODS = 'toString,toJSON,get,set,update,save,destroy'

--- a/lib/entity_spec.js
+++ b/lib/entity_spec.js
@@ -8,4 +8,4 @@
 exports.RESERVED_ATTRIBUTES = 'id,$$at,$$seal,$$by,$$policy,$$as'
 
 /** Reserved method names */
-exports.RESERVED_METHODS = 'toString,toJSON,get,set,update,save,destroy'
+exports.RESERVED_METHODS = 'toString,toJSON,get,set,sync,update,save,destroy'


### PR DESCRIPTION
これらと同じ名前のattributeをDBに保存することを許さないようにするつもり


```javascript

userResource.update(id, {toString: 'Some foolish update!'}) // -> Throw error!

```